### PR TITLE
get thread channel permissions from parent

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1216,9 +1216,9 @@ declare namespace Eris {
       GUILD_CATEGORY: 4;
       GUILD_NEWS: 5;
       GUILD_STORE: 6;
-      GUILD_NEWS_THREAD: 10,
-      GUILD_PUBLIC_THREAD: 11,
-      GUILD_PRIVATE_THREAD: 12,
+      GUILD_NEWS_THREAD: 10;
+      GUILD_PUBLIC_THREAD: 11;
+      GUILD_PRIVATE_THREAD: 12;
       GUILD_STAGE: 13;
     };
     GATEWAY_VERSION: 9;
@@ -2394,9 +2394,10 @@ declare namespace Eris {
     reactions: { [s: string]: { count: number; me: boolean } };
     referencedMessage?: Message | null;
     roleMentions: string[];
+    stickerItems?: StickerItems[];
     /** @deprecated */
     stickers?: Sticker[];
-    stickerItems?: StickerItems[];
+
     timestamp: number;
     tts: boolean;
     type: number;
@@ -2510,7 +2511,7 @@ declare namespace Eris {
     unpinMessage(messageID: string): Promise<void>;
     unsendMessage(messageID: string): Promise<void>;
   }
-  
+
   export class PrivateThreadChannel extends ThreadChannel {
     type: 12;
     createMessage(content: MessageContent, file?: MessageFile | MessageFile): Promise<Message<PrivateThreadChannel>>;
@@ -2689,16 +2690,19 @@ declare namespace Eris {
   }
 
   export class StageInstance extends Base {
-    client: Client;
     channel: StageChannel | Uncached;
+    client: Client;
+
     discoverableDisabled: boolean;
     guild: Guild | Uncached;
     privacyLevel: StageInstancePrivacyLevel;
     topic: string;
     constructor(data: BaseData, client: Client);
-    update(data: BaseData): void;
     delete(): Promise<void>;
     edit(options: StageInstanceOptions): Promise<StageInstance>;
+    update(data: BaseData): void;
+
+
   }
 
   export class StoreChannel extends GuildChannel {
@@ -2720,8 +2724,9 @@ declare namespace Eris {
     addMessageReaction(messageID: string, reaction: string, userID: string): Promise<void>;
     createInvite(options?: CreateInviteOptions, reason?: string): Promise<Invite<"withMetadata", TextChannel>>;
     createMessage(content: MessageContent, file?: MessageFile | MessageFile[]): Promise<Message<TextChannel>>;
-    createThreadWithoutMessage(options: CreateThreadWithoutMessageOptions): Promise<PrivateThreadChannel>;
     createThreadWithMessage(messageID: string, options: CreateThreadOptions): Promise<PublicThreadChannel>;
+    createThreadWithoutMessage(options: CreateThreadWithoutMessageOptions): Promise<PrivateThreadChannel>;
+
     createWebhook(options: { name: string; avatar?: string | null}, reason?: string): Promise<Webhook>;
     deleteMessage(messageID: string, reason?: string): Promise<void>;
     deleteMessages(messageIDs: string[], reason?: string): Promise<void>;
@@ -2790,11 +2795,13 @@ declare namespace Eris {
 
   export class ThreadMember extends Base {
     client: Client;
-    threadID: string;
     joinTimestamp: number;
+    threadID: string;
+
     constructor(data: BaseData, client: Client);
-    update(data: BaseData): void;
     leave(): Promise<void>;
+    update(data: BaseData): void;
+
   }
 
   export class UnavailableGuild extends Base {

--- a/lib/structures/GuildChannel.js
+++ b/lib/structures/GuildChannel.js
@@ -129,7 +129,7 @@ class GuildChannel extends Channel {
         }
 
         let channelPermissionOverwrites;
-        if(this.parentID && this.type === 10 || this.type === 11){
+        if(this.parentID && (this.type === 10 || this.type === 11 || this.type === 12)){
             const parentChannel = this.client.getChannel(this.parentID);
             if(parentChannel) {
                 channelPermissionOverwrites = parentChannel.permissionOverwrites;

--- a/lib/structures/GuildChannel.js
+++ b/lib/structures/GuildChannel.js
@@ -127,20 +127,30 @@ class GuildChannel extends Channel {
         if(permission & Permissions.administrator) {
             return new Permission(Permissions.all);
         }
-        let overwrite = this.permissionOverwrites.get(this.guild.id);
+
+        let channelPermissionOverwrites; 
+        if (this.type === 0 || this.type === 5){
+            channelPermissionOverwrites = this.permissionOverwrites;
+        }else{
+            const parentChannel = this.client.getChannel(this.parentID);
+            if (parentChannel) channelPermissionOverwrites = parentChannel.permissionOverwrites;
+            else channelPermissionOverwrites = new Collection(PermissionOverwrite);
+        }
+
+        let overwrite = channelPermissionOverwrites.get(this.guild.id);
         if(overwrite) {
             permission = (permission & ~overwrite.deny) | overwrite.allow;
         }
         let deny = 0n;
         let allow = 0n;
         for(const roleID of member.roles) {
-            if((overwrite = this.permissionOverwrites.get(roleID))) {
+            if((overwrite = channelPermissionOverwrites.get(roleID))) {
                 deny |= overwrite.deny;
                 allow |= overwrite.allow;
             }
         }
         permission = (permission & ~deny) | allow;
-        overwrite = this.permissionOverwrites.get(member.id);
+        overwrite = channelPermissionOverwrites.get(member.id);
         if(overwrite) {
             permission = (permission & ~overwrite.deny) | overwrite.allow;
         }

--- a/lib/structures/GuildChannel.js
+++ b/lib/structures/GuildChannel.js
@@ -128,13 +128,16 @@ class GuildChannel extends Channel {
             return new Permission(Permissions.all);
         }
 
-        let channelPermissionOverwrites; 
-        if (this.type === 0 || this.type === 5){
+        let channelPermissionOverwrites;
+        if(this.type === 0 || this.type === 5){
             channelPermissionOverwrites = this.permissionOverwrites;
-        }else{
+        } else {
             const parentChannel = this.client.getChannel(this.parentID);
-            if (parentChannel) channelPermissionOverwrites = parentChannel.permissionOverwrites;
-            else channelPermissionOverwrites = new Collection(PermissionOverwrite);
+            if(parentChannel) {
+                channelPermissionOverwrites = parentChannel.permissionOverwrites;
+            } else {
+                channelPermissionOverwrites = new Collection(PermissionOverwrite);
+            }
         }
 
         let overwrite = channelPermissionOverwrites.get(this.guild.id);

--- a/lib/structures/GuildChannel.js
+++ b/lib/structures/GuildChannel.js
@@ -129,15 +129,15 @@ class GuildChannel extends Channel {
         }
 
         let channelPermissionOverwrites;
-        if(this.type === 0 || this.type === 5){
-            channelPermissionOverwrites = this.permissionOverwrites;
-        } else {
+        if(this.parentID && this.type === 10 || this.type === 11){
             const parentChannel = this.client.getChannel(this.parentID);
             if(parentChannel) {
                 channelPermissionOverwrites = parentChannel.permissionOverwrites;
             } else {
                 channelPermissionOverwrites = new Collection(PermissionOverwrite);
             }
+        } else {
+            channelPermissionOverwrites = this.permissionOverwrites;
         }
 
         let overwrite = channelPermissionOverwrites.get(this.guild.id);


### PR DESCRIPTION
Thread channels payload contain no permission information so `permissionsOf` doesn't work in them. Since thread channels have no permissions of their own and tecnically inherit the parent channel's permissions, this will switch the reference to the parent channel's `permissionOverwirites` if channel type is either 10 or 11. 